### PR TITLE
Fix GHCR image tags in Snyk/Trivy workflows and guard missing image variants

### DIFF
--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   snyk:
-    name: Snyk container (latest + hardened + locked)
+    name: Snyk container (latest + distroless + locked)
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,9 +28,9 @@ jobs:
           - name: latest
             repo: parsedmarc
             tag: latest
-          - name: hardened
+          - name: distroless
             repo: parsedmarc
-            tag: hardened
+            tag: distroless
           - name: locked-alpine
             repo: parsedmarc-locked
             tag: alpine
@@ -56,8 +56,8 @@ jobs:
               latest)
                 echo "IMAGE_REF=${BASE}:${VER}" >> "$GITHUB_OUTPUT"
                 ;;
-              hardened)
-                echo "IMAGE_REF=${BASE}:${VER}-hardened" >> "$GITHUB_OUTPUT"
+              distroless)
+                echo "IMAGE_REF=${BASE}:${VER}-distroless" >> "$GITHUB_OUTPUT"
                 ;;
               locked-alpine)
                 echo "IMAGE_REF=${BASE}:${VER}-alpine" >> "$GITHUB_OUTPUT"
@@ -83,10 +83,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check image exists in GHCR
+        id: image_check
+        shell: bash
+        run: |
+          if docker manifest inspect "${{ steps.ref.outputs.IMAGE_REF }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image not available yet: ${{ steps.ref.outputs.IMAGE_REF }}"
+          fi
+
       - name: Pull published image
+        if: steps.image_check.outputs.exists == 'true'
         run: docker pull "${{ steps.ref.outputs.IMAGE_REF }}"
 
       - name: Snyk scan (SARIF)
+        if: steps.image_check.outputs.exists == 'true'
         uses: snyk/actions/docker@14818c4695ecc4045f33c9cee9e795a788711ca4
         continue-on-error: true
         env:
@@ -98,6 +111,7 @@ jobs:
             --severity-threshold=high
 
       - name: Upload SARIF to GitHub Security
+        if: steps.image_check.outputs.exists == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snyk-container-${{ matrix.target.name }}.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   trivy:
-    name: Trivy (latest + hardened + locked)
+    name: Trivy (latest + distroless + locked)
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,9 +28,9 @@ jobs:
           - name: latest
             repo: parsedmarc
             tag: latest
-          - name: hardened
+          - name: distroless
             repo: parsedmarc
-            tag: hardened
+            tag: distroless
           - name: locked-alpine
             repo: parsedmarc-locked
             tag: alpine
@@ -56,8 +56,8 @@ jobs:
               latest)
                 echo "IMAGE_REF=${BASE}:${VER}" >> "$GITHUB_OUTPUT"
                 ;;
-              hardened)
-                echo "IMAGE_REF=${BASE}:${VER}-hardened" >> "$GITHUB_OUTPUT"
+              distroless)
+                echo "IMAGE_REF=${BASE}:${VER}-distroless" >> "$GITHUB_OUTPUT"
                 ;;
               locked-alpine)
                 echo "IMAGE_REF=${BASE}:${VER}-alpine" >> "$GITHUB_OUTPUT"
@@ -83,10 +83,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check image exists in GHCR
+        id: image_check
+        shell: bash
+        run: |
+          if docker manifest inspect "${{ steps.ref.outputs.IMAGE_REF }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image not available yet: ${{ steps.ref.outputs.IMAGE_REF }}"
+          fi
+
       - name: Pull published image
+        if: steps.image_check.outputs.exists == 'true'
         run: docker pull "${{ steps.ref.outputs.IMAGE_REF }}"
 
       - name: Trivy scan (SARIF)
+        if: steps.image_check.outputs.exists == 'true'
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe # v0.30.0
         with:
           image-ref: ${{ steps.ref.outputs.IMAGE_REF }}
@@ -98,6 +111,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload SARIF to GitHub Security
+        if: steps.image_check.outputs.exists == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-${{ matrix.target.name }}.sarif


### PR DESCRIPTION
### Motivation
- Security scan workflows referenced a non-published `hardened` tag for `parsedmarc` which caused pull failures. 
- The `parsedmarc-locked:ubi` variant is not always published and hard `docker pull` failures broke entire scan jobs. 
- Ensure scan workflows target tags actually produced by the build pipeline (notably `distroless`) and fail gracefully when a variant is missing.

### Description
- Replaced `hardened` with `distroless` in the matrix targets and in release tag resolution in `.github/workflows/snyk-container.yml` and `.github/workflows/trivy.yml`. 
- Added a `Check image exists in GHCR` step using `docker manifest inspect` and set `if: steps.image_check.outputs.exists == 'true'` on subsequent `docker pull`, scan, and SARIF upload steps to skip missing variants. 
- Applied the same guard to both Snyk and Trivy workflows so missing published variants no longer fail the whole job. 
- Changes were committed as part of the PR `Fix GHCR image tags in Snyk/Trivy workflows and guard missing image variants`.

### Testing
- Parsed all workflow YAML files with Ruby using `require "yaml"; Dir[".github/workflows/*.yml"].sort.each{|p| YAML.load_file(p)}` and the YAML load succeeded for all modified files. 
- Attempted a Python-based YAML validation with `python - <<'PY' ...` which failed due to missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`). 
- Tried a local Docker build of the UBI locked Dockerfile with `docker build -f Dockerfile-ubi.locked ...`, which could not be run because `docker` is not available in the environment. 
- The workflow file changes were committed successfully (`git commit`) and packaged into this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c562b5e5c83329e93ad8b32494cba)