### PR TITLE
Switch to root for UBI locked image prep and guard published-image scans

### DIFF
--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   snyk:
-    name: Snyk container (latest + hardened + locked)
+    name: Snyk container (latest + distroless + locked)
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,9 +28,9 @@ jobs:
           - name: latest
             repo: parsedmarc
             tag: latest
-          - name: hardened
+          - name: distroless
             repo: parsedmarc
-            tag: hardened
+            tag: distroless
           - name: locked-alpine
             repo: parsedmarc-locked
             tag: alpine
@@ -56,8 +56,8 @@ jobs:
               latest)
                 echo "IMAGE_REF=${BASE}:${VER}" >> "$GITHUB_OUTPUT"
                 ;;
-              hardened)
-                echo "IMAGE_REF=${BASE}:${VER}-hardened" >> "$GITHUB_OUTPUT"
+              distroless)
+                echo "IMAGE_REF=${BASE}:${VER}-distroless" >> "$GITHUB_OUTPUT"
                 ;;
               locked-alpine)
                 echo "IMAGE_REF=${BASE}:${VER}-alpine" >> "$GITHUB_OUTPUT"
@@ -83,10 +83,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check image exists in GHCR
+        id: image_check
+        shell: bash
+        run: |
+          if docker manifest inspect "${{ steps.ref.outputs.IMAGE_REF }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image not available yet: ${{ steps.ref.outputs.IMAGE_REF }}"
+          fi
+
       - name: Pull published image
+        if: steps.image_check.outputs.exists == 'true'
         run: docker pull "${{ steps.ref.outputs.IMAGE_REF }}"
 
       - name: Snyk scan (SARIF)
+        if: steps.image_check.outputs.exists == 'true'
         uses: snyk/actions/docker@14818c4695ecc4045f33c9cee9e795a788711ca4
         continue-on-error: true
         env:
@@ -98,6 +111,7 @@ jobs:
             --severity-threshold=high
 
       - name: Upload SARIF to GitHub Security
+        if: steps.image_check.outputs.exists == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snyk-container-${{ matrix.target.name }}.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   trivy:
-    name: Trivy (latest + hardened + locked)
+    name: Trivy (latest + distroless + locked)
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,9 +28,9 @@ jobs:
           - name: latest
             repo: parsedmarc
             tag: latest
-          - name: hardened
+          - name: distroless
             repo: parsedmarc
-            tag: hardened
+            tag: distroless
           - name: locked-alpine
             repo: parsedmarc-locked
             tag: alpine
@@ -56,8 +56,8 @@ jobs:
               latest)
                 echo "IMAGE_REF=${BASE}:${VER}" >> "$GITHUB_OUTPUT"
                 ;;
-              hardened)
-                echo "IMAGE_REF=${BASE}:${VER}-hardened" >> "$GITHUB_OUTPUT"
+              distroless)
+                echo "IMAGE_REF=${BASE}:${VER}-distroless" >> "$GITHUB_OUTPUT"
                 ;;
               locked-alpine)
                 echo "IMAGE_REF=${BASE}:${VER}-alpine" >> "$GITHUB_OUTPUT"
@@ -83,10 +83,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check image exists in GHCR
+        id: image_check
+        shell: bash
+        run: |
+          if docker manifest inspect "${{ steps.ref.outputs.IMAGE_REF }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image not available yet: ${{ steps.ref.outputs.IMAGE_REF }}"
+          fi
+
       - name: Pull published image
+        if: steps.image_check.outputs.exists == 'true'
         run: docker pull "${{ steps.ref.outputs.IMAGE_REF }}"
 
       - name: Trivy scan (SARIF)
+        if: steps.image_check.outputs.exists == 'true'
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe # v0.30.0
         with:
           image-ref: ${{ steps.ref.outputs.IMAGE_REF }}
@@ -98,6 +111,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload SARIF to GitHub Security
+        if: steps.image_check.outputs.exists == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-${{ matrix.target.name }}.sarif

--- a/Dockerfile-ubi.locked
+++ b/Dockerfile-ubi.locked
@@ -44,6 +44,9 @@ ENV PATH="${VENV_PATH}/bin:${PATH}"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
+# UBI python image can default to a non-root user; switch to root for filesystem prep.
+USER 0
+
 # katalogi pod Twój compose
 RUN mkdir -p /opt/app/ini /var/log/parsedmarc \
  && chown -R 1001:0 /opt/app /var/log/parsedmarc \


### PR DESCRIPTION
### Motivation
- The UBI runtime stage attempted privileged filesystem operations while the image could default to a non-root user, causing `mkdir`/`chown` permission failures and preventing publication of the `parsedmarc-locked:ubi` tags. 
- Scan workflows referenced a `hardened` tag that is not produced and could fail on missing image variants, so they should target a produced tag and skip scans for absent images.

### Description
- Updated `Dockerfile-ubi.locked` to add `USER 0` before the filesystem preparation `RUN mkdir -p /opt/app/ini /var/log/parsedmarc ...` and restored `USER 1001` after, so prep runs with root privileges and the final image stays non-root. 
- Replaced `hardened` with `distroless` in the Snyk and Trivy workflow matrices and release tag resolution. 
- Added an image existence check step using `docker manifest inspect` in both `.github/workflows/snyk-container.yml` and `.github/workflows/trivy.yml`, and gated the `docker pull`, scan, and SARIF upload steps with `if: steps.image_check.outputs.exists == 'true'` to skip missing variants. 

### Testing
- Verified Dockerfile ordering with a small `python` check that asserts `USER 0` appears before the `RUN mkdir` step and that `USER 1001` appears after, and the assertion succeeded. 
- Parsed all workflow YAML files with `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each{|p| YAML.load_file(p)}'` and the YAML load succeeded (`WORKFLOW_YAML_OK`). 
- Inspected the failing build log snippet showing `mkdir: cannot create directory … Permission denied`, and confirmed the `USER 0` insertion addresses that root cause based on file ordering verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c562b5e5c83329e93ad8b32494cba)