### PR TITLE
Fix UBI builder /opt/venv permission and gate published-image scans (distroless)

### DIFF
--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   snyk:
-    name: Snyk container (latest + hardened + locked)
+    name: Snyk container (latest + distroless + locked)
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,9 +28,9 @@ jobs:
           - name: latest
             repo: parsedmarc
             tag: latest
-          - name: hardened
+          - name: distroless
             repo: parsedmarc
-            tag: hardened
+            tag: distroless
           - name: locked-alpine
             repo: parsedmarc-locked
             tag: alpine
@@ -56,8 +56,8 @@ jobs:
               latest)
                 echo "IMAGE_REF=${BASE}:${VER}" >> "$GITHUB_OUTPUT"
                 ;;
-              hardened)
-                echo "IMAGE_REF=${BASE}:${VER}-hardened" >> "$GITHUB_OUTPUT"
+              distroless)
+                echo "IMAGE_REF=${BASE}:${VER}-distroless" >> "$GITHUB_OUTPUT"
                 ;;
               locked-alpine)
                 echo "IMAGE_REF=${BASE}:${VER}-alpine" >> "$GITHUB_OUTPUT"
@@ -83,10 +83,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check image exists in GHCR
+        id: image_check
+        shell: bash
+        run: |
+          if docker manifest inspect "${{ steps.ref.outputs.IMAGE_REF }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image not available yet: ${{ steps.ref.outputs.IMAGE_REF }}"
+          fi
+
       - name: Pull published image
+        if: steps.image_check.outputs.exists == 'true'
         run: docker pull "${{ steps.ref.outputs.IMAGE_REF }}"
 
       - name: Snyk scan (SARIF)
+        if: steps.image_check.outputs.exists == 'true'
         uses: snyk/actions/docker@14818c4695ecc4045f33c9cee9e795a788711ca4
         continue-on-error: true
         env:
@@ -98,6 +111,7 @@ jobs:
             --severity-threshold=high
 
       - name: Upload SARIF to GitHub Security
+        if: steps.image_check.outputs.exists == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snyk-container-${{ matrix.target.name }}.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   trivy:
-    name: Trivy (latest + hardened + locked)
+    name: Trivy (latest + distroless + locked)
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,9 +28,9 @@ jobs:
           - name: latest
             repo: parsedmarc
             tag: latest
-          - name: hardened
+          - name: distroless
             repo: parsedmarc
-            tag: hardened
+            tag: distroless
           - name: locked-alpine
             repo: parsedmarc-locked
             tag: alpine
@@ -56,8 +56,8 @@ jobs:
               latest)
                 echo "IMAGE_REF=${BASE}:${VER}" >> "$GITHUB_OUTPUT"
                 ;;
-              hardened)
-                echo "IMAGE_REF=${BASE}:${VER}-hardened" >> "$GITHUB_OUTPUT"
+              distroless)
+                echo "IMAGE_REF=${BASE}:${VER}-distroless" >> "$GITHUB_OUTPUT"
                 ;;
               locked-alpine)
                 echo "IMAGE_REF=${BASE}:${VER}-alpine" >> "$GITHUB_OUTPUT"
@@ -83,10 +83,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check image exists in GHCR
+        id: image_check
+        shell: bash
+        run: |
+          if docker manifest inspect "${{ steps.ref.outputs.IMAGE_REF }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image not available yet: ${{ steps.ref.outputs.IMAGE_REF }}"
+          fi
+
       - name: Pull published image
+        if: steps.image_check.outputs.exists == 'true'
         run: docker pull "${{ steps.ref.outputs.IMAGE_REF }}"
 
       - name: Trivy scan (SARIF)
+        if: steps.image_check.outputs.exists == 'true'
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe # v0.30.0
         with:
           image-ref: ${{ steps.ref.outputs.IMAGE_REF }}
@@ -98,6 +111,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload SARIF to GitHub Security
+        if: steps.image_check.outputs.exists == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-${{ matrix.target.name }}.sarif

--- a/Dockerfile-ubi.locked
+++ b/Dockerfile-ubi.locked
@@ -14,6 +14,9 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
+# UBI python image can default to non-root; root is required to create /opt/venv.
+USER 0
+
 WORKDIR /src
 COPY requirements.lock /src/requirements.lock
 
@@ -43,6 +46,9 @@ ENV VENV_PATH=/opt/venv
 ENV PATH="${VENV_PATH}/bin:${PATH}"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+
+# UBI python image can default to a non-root user; switch to root for filesystem prep.
+USER 0
 
 # katalogi pod Twój compose
 RUN mkdir -p /opt/app/ini /var/log/parsedmarc \


### PR DESCRIPTION
### Motivation
- The UBI builder stage failed with `Permission denied: '/opt/venv'` because the base image can default to a non-root user and the venv creation needs root. 
- Published-image scan workflows referenced a non-produced `hardened` tag and attempted to scan image variants that may not exist, causing scan failures.

### Description
- Added `USER 0` in the builder stage of `Dockerfile-ubi.locked` so `python -m venv "${VENV_PATH}"` runs with root privileges. 
- Kept the runtime-stage fix that switches to `USER 0` for `/opt/app` and `/var/log/parsedmarc` prep and restores `USER 1001` for the final image. 
- Replaced `hardened` with `distroless` in `.github/workflows/snyk-container.yml` and `.github/workflows/trivy.yml` so workflows reference an actually produced tag. 
- Added an image existence check using `docker manifest inspect` and gated `docker pull`, the scanner steps, and SARIF uploads with `if: steps.image_check.outputs.exists == 'true'` to skip missing variants.

### Testing
- Ran a Python ordering assertion that verified `USER 0` appears before the `RUN python -m venv` step and that runtime `USER 0` precedes the directory prep and `USER 1001` finalization, and the assertion succeeded. 
- Parsed the modified workflow YAMLs to ensure they load as valid YAML, and the parse succeeded. 
- Did not run `docker build` locally in this environment, so no live image build was executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c562b5e5c83329e93ad8b32494cba)